### PR TITLE
Add missing service aliases in order to allow autowiring

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -18,12 +18,18 @@ services:
         parent: rs_queue.service
         public: true
 
+    RSQueue\Services\Consumer: "@rs_queue.consumer"
+
     rs_queue.producer:
         class: RSQueue\Services\Producer
         parent: rs_queue.service
         public: true
 
+    RSQueue\Services\Producer: "@rs_queue.producer"
+
     rs_queue.publisher:
         class: RSQueue\Services\Publisher
         parent: rs_queue.service
         public: true
+
+    RSQueue\Services\Publisher: "@rs_queue.publisher"


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

See https://symfony.com/doc/current/service_container/autowiring.html#using-aliases-to-enable-autowiring.