### PR TITLE
Use Twig namespaced syntax

### DIFF
--- a/Resources/config/collector.yml
+++ b/Resources/config/collector.yml
@@ -3,6 +3,6 @@ services:
     rs_queue.data_collector:
         class: RSQueueBundle\Collector\RSQueueCollector
         tags:
-            - { name: data_collector, template: "RSQueueBundle:Collector:rsqueue", id: "rsqueue_collector" }
+            - { name: data_collector, template: "@RSQueue/Collector/rsqueue.html.twig", id: "rsqueue_collector" }
             - { name: kernel.event_listener, event: rsqueue.producer, method: onProducerAction }
             - { name: kernel.event_listener, event: rsqueue.publisher, method: onPublisherAction }

--- a/Resources/views/Collector/rsqueue.html.twig
+++ b/Resources/views/Collector/rsqueue.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {# the web debug toolbar content #}
@@ -16,7 +16,7 @@
             <span>{{ collector.publisher|length }}</span>
         </div>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}


### PR DESCRIPTION
Use Twig namespaced syntax in order to keep compatible with the absence of deprecated `framework.templating` configuration node.

See [**Framework Configuration Reference**](https://symfony.com/doc/current/reference/configuration/framework.html#templating).
